### PR TITLE
Improve the gyro latency.

### DIFF
--- a/handycon.py
+++ b/handycon.py
@@ -874,6 +874,7 @@ async def emit_events(events: list):
         for event in events:
             ui_device.write_event(event)
             ui_device.syn()
+            await asyncio.sleep(0.09)
 
 # Gracefull shutdown.
 async def restore_all(loop):


### PR DESCRIPTION
Improve the gryo latency by removing the controller_events queue. The `EV_ABS` events are emitted in the `capture_controller_events()` loop directly.

I also updated when the `last_x_val` and `last_y_val` are updated. They are now updated with the event value before adjustment. I find the gyro can generate `EV_ABS` events with big value even if the R-stick is back to the origin. It turns out that although there is always an even that resets `last_x_val`, the adjusted value is not zero. So the offset persists and lead to unexpected behavior. 

I also deleted the sleep in `emit_events()`. It turns out most of the cases the emit array has only 1 element. And there are two cases with 2 elements:
* In `capture_keyboard_events()` it shouldn't happen too frequently.
* In `capture_gyro_events()` there is a sleep call right after `emit_events()`. So in case the interval is too small we can just tune the value there. 