### PR TITLE
Fix potential race condition with suspend.

### DIFF
--- a/usr/share/handygccs/scripts/handycon.py
+++ b/usr/share/handygccs/scripts/handycon.py
@@ -935,15 +935,21 @@ def steam_ifrunning_deckui(cmd):
         logger.error(f"{err} | Error getting steam PID.")
         return False
 
-    # Use `ps -fp PID` to extract the full Steam commandline.
+    # Get the commandline for the Steam process by checking /proc.
+    steam_cmd_path = f"/proc/{pid}/cmdline"
+    if not os.path.exists(steam_cmd_path):
+        # Steam not running.
+        return False
+
     try:
-        steam_cmd = subprocess.run(f"ps -fp {pid}", stdin=subprocess.PIPE, capture_output=True, shell=True, check=True).stdout
+        with open(steam_cmd_path, "rb") as f:
+            steam_cmd = f.read()
     except Exception as err:
         logger.error(f"{err} | Error getting steam cmdline.")
         return False
 
     # Use this commandline to determine if Steam is running in DeckUI mode.
-    # e.g. "steam://shortpowerpress" only work in DeckUI.
+    # e.g. "steam://shortpowerpress" only works in DeckUI.
     is_deckui = b"-gamepadui" in steam_cmd
     if not is_deckui:
         return False

--- a/usr/share/handygccs/scripts/handycon.py
+++ b/usr/share/handygccs/scripts/handycon.py
@@ -930,7 +930,7 @@ def steam_ifrunning_deckui(cmd):
     steampid_path = HOME_PATH / '.steam/steam.pid'
     try:
         with open(steampid_path) as f:
-            pid = f.read()
+            pid = f.read().strip()
     except Exception as err:
         logger.error(f"{err} | Error getting steam PID.")
         return False

--- a/usr/share/handygccs/scripts/handycon.py
+++ b/usr/share/handygccs/scripts/handycon.py
@@ -975,8 +975,8 @@ async def capture_power_events():
                                 # For DeckUI Sessions
                                 is_deckui = steam_ifrunning_deckui("steam://shortpowerpress")
                                 if not is_deckui:
-                                  # For BPM and Desktop sessions
-                                  os.system('systemctl suspend')
+                                    # For BPM and Desktop sessions
+                                    os.system('systemctl suspend')
 
                     if active_keys == [125]:
                         await do_rumble(0, 150, 1000, 0)

--- a/usr/share/handygccs/scripts/handycon.py
+++ b/usr/share/handygccs/scripts/handycon.py
@@ -926,6 +926,7 @@ async def capture_gyro_events():
                 break
 
 def steam_ifrunning_deckui(cmd):
+    # Get the currently running Steam PID.
     steampid_path = HOME_PATH / '.steam/steam.pid'
     try:
         with open(steampid_path) as f:
@@ -934,12 +935,15 @@ def steam_ifrunning_deckui(cmd):
         logger.error(f"{err} | Error getting steam PID.")
         return False
 
+    # Use `ps -fp PID` to extract the full Steam commandline.
     try:
         steam_cmd = subprocess.run(f"ps -fp {pid}", stdin=subprocess.PIPE, capture_output=True, shell=True, check=True).stdout
     except Exception as err:
         logger.error(f"{err} | Error getting steam cmdline.")
         return False
 
+    # Use this commandline to determine if Steam is running in DeckUI mode.
+    # e.g. "steam://shortpowerpress" only work in DeckUI.
     is_deckui = b"-gamepadui" in steam_cmd
     if not is_deckui:
         return False


### PR DESCRIPTION
The previous approach led to frequent race conditions, where the first power button press
to resume my device causes the device to instantly go to sleep again. This seems to be
because of some timing issues with the fallback `systemctl suspend` call that happens after
the initial steam `-ifrunning steam://shortpowerpress` call. 

Instead, we check explicitly if we're running in deckui mode, and don't do the
`systemctl suspend` call if so.

Tested that this works as expected in:
- Deck UI sessions
- Desktop sessions (with and without Steam running) 