### PR TITLE
launch chimera app if available with LC (select Aya devices)

### DIFF
--- a/usr/share/handygccs/scripts/handycon.py
+++ b/usr/share/handygccs/scripts/handycon.py
@@ -62,6 +62,9 @@ EVENT_MAP= {
 
 HIDE_PATH = Path(HIDE_PATH)
 
+CHIMERA_LAUNCHER_PATH='/usr/share/chimera/bin/chimera-web-launcher'
+HAS_CHIMERA_LAUNCHER=os.path.isfile(CHIMERA_LAUNCHER_PATH)
+
 server_address = '/tmp/ryzenadj_socket'
 
 # Capture the username and home path of the user who has been logged in the longest.
@@ -634,10 +637,13 @@ async def capture_keyboard_events():
                             # This device class uses the same active events with different values for AYA SPACE, LC, and RC.
                             if active == [97, 125]:
 
-                                # LC | Default: Screenshot
+                                # LC | Default: Screenshot / Launch Chimera
                                 if button_on == 102 and event_queue == []:
-                                    event_queue.append(button1)
-                                    this_button = button1
+                                    if HAS_CHIMERA_LAUNCHER:
+                                        launch_chimera()
+                                    else:
+                                        event_queue.append(button1)
+                                        this_button = button1
                                 # RC | Default: OSK
                                 elif button_on == 103 and event_queue == []:
                                     event_queue.append(button4)
@@ -1117,6 +1123,11 @@ async def ryzenadj_control(loop):
                 await asyncio.sleep(RYZENADJ_DELAY)
                 continue
         await asyncio.sleep(RYZENADJ_DELAY)
+
+def launch_chimera():
+    if not HAS_CHIMERA_LAUNCHER:
+        return
+    subprocess.run([ "su", USER, "-c", CHIMERA_LAUNCHER_PATH ])
 
 # Gracefull shutdown.
 async def restore_all(loop):


### PR DESCRIPTION
This change will make the 'LC' button on Aya Neo 2 and Aya Neo Geek launch the chimera web app if it is installed.
Otherwise, the existing functionality of taking a screenshot will occur.

This will allow supported devices to have easy access to TDP controls, among other functionality from directly within gaming mode/gamescope session.

Tested on Aya Neo 2.