### PR TITLE
Add ayaneo air 1s support

### DIFF
--- a/src/handycon/devices.py
+++ b/src/handycon/devices.py
@@ -17,6 +17,7 @@ import handycon.handhelds.aya_gen3 as aya_gen3
 import handycon.handhelds.aya_gen4 as aya_gen4
 import handycon.handhelds.aya_gen5 as aya_gen5
 import handycon.handhelds.aya_gen6 as aya_gen6
+import handycon.handhelds.aya_gen7 as aya_gen7
 import handycon.handhelds.ayn_gen1 as ayn_gen1
 import handycon.handhelds.gpd_gen1 as gpd_gen1
 import handycon.handhelds.gpd_gen2 as gpd_gen2
@@ -253,6 +254,8 @@ async def capture_keyboard_events():
                             await aya_gen5.process_event(seed_event, active_keys)
                         case "AYA_GEN6":
                             await aya_gen6.process_event(seed_event, active_keys)
+                        case "AYA_GEN7":
+                            await aya_gen7.process_event(seed_event, active_keys)
                         case "AYN_GEN1":
                             await ayn_gen1.process_event(seed_event, active_keys)
                         case "GPD_GEN1":

--- a/src/handycon/handhelds/aya_gen2.py
+++ b/src/handycon/handhelds/aya_gen2.py
@@ -49,10 +49,10 @@ async def process_event(seed_event, active_keys):
     # BUTTON 5 (Default: MODE) Big button
     if active_keys in [[96, 105, 133], [88, 97, 125]] and button_on == 1 and button5 not in handycon.event_queue:
         handycon.event_queue.append(button5)
-        await handycon.emit_now(seed_event, button2, 1)
-    elif active == [] and seed_event.code in [88, 96, 97, 105, 125, 133] and button_on == 0 and button5 in handycon.event_queue:
-        handycon.event_queue.remove(button5)
         await handycon.emit_now(seed_event, button5, 1)
+    elif active_keys == [] and seed_event.code in [88, 96, 97, 105, 125, 133] and button_on == 0 and button5 in handycon.event_queue:
+        handycon.event_queue.remove(button5)
+        await handycon.emit_now(seed_event, button5, 0)
 
     # Handle L_META from power button
     elif active_keys == [] and seed_event.code == 125 and button_on == 0 and handycon.event_queue == [] and handycon.shutdown == True:

--- a/src/handycon/handhelds/aya_gen7.py
+++ b/src/handycon/handhelds/aya_gen7.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+# This file is part of Handheld Game Console Controller System (HandyGCCS)
+# Copyright 2022-2023 Derek J. Clark <derekjohn.clark@gmail.com>
+
+import sys
+from evdev import InputDevice, InputEvent, UInput, ecodes as e, list_devices, ff
+
+from .. import constants as cons
+
+handycon = None
+
+def init_handheld(handheld_controller):
+    global handycon
+    handycon = handheld_controller
+    handycon.BUTTON_DELAY = 0.10
+    handycon.CAPTURE_CONTROLLER = True
+    handycon.CAPTURE_KEYBOARD = True
+    handycon.CAPTURE_POWER = True
+    handycon.GAMEPAD_ADDRESS = 'usb-0000:c4:00.3-4/input0'
+    handycon.GAMEPAD_NAME = 'Microsoft X-Box 360 pad'
+    handycon.KEYBOARD_ADDRESS = 'isa0060/serio0/input0'
+    handycon.KEYBOARD_NAME = 'AT Translated Set 2 keyboard'
+
+
+# Captures keyboard events and translates them to virtual device events.
+async def process_event(seed_event, active_keys):
+    global handycon
+
+    # Button map shortcuts for easy reference.
+    button2 = handycon.button_map["button2"]  # Default QAM
+    button5 = handycon.button_map["button5"]  # Default MODE
+
+    ## Loop variables
+    button_on = seed_event.value
+
+    # Automatically pass default keycodes we dont intend to replace.
+    if seed_event.code in [e.KEY_VOLUMEDOWN, e.KEY_VOLUMEUP]:
+        await handycon.emit_events([seed_event])
+
+    # BUTTON 2 (Default: QAM) Small Button
+    if active_keys in [[32, 125], [125]] and button_on == 1 and button2 not in handycon.event_queue:
+        handycon.event_queue.append(button2)
+        await handycon.emit_now(seed_event, button2, 1)
+        await handycon.do_rumble(0, 150, 1000, 0)
+        handycon.event_queue.remove(button2)
+        await handycon.emit_now(seed_event, button2, 0)
+
+    # BUTTON 5 (Default: MODE) Big button
+    if active_keys == [97] and button_on == 1 and button5 not in handycon.event_queue:
+        handycon.event_queue.append(button5)
+        await handycon.emit_now(seed_event, button5, 1)
+    elif active_keys == [] and seed_event.code == 97 and button_on == 0 and button5 in handycon.event_queue:
+        handycon.event_queue.remove(button5)
+        await handycon.emit_now(seed_event, button5, 0)
+
+    # Handle L_META from power button
+    elif active_keys == [] and seed_event.code == 125 and button_on == 0 and handycon.event_queue == [] and handycon.shutdown == True:
+        handycon.shutdown = False

--- a/src/handycon/utilities.py
+++ b/src/handycon/utilities.py
@@ -21,6 +21,7 @@ import handycon.handhelds.aya_gen3 as aya_gen3
 import handycon.handhelds.aya_gen4 as aya_gen4
 import handycon.handhelds.aya_gen5 as aya_gen5
 import handycon.handhelds.aya_gen6 as aya_gen6
+import handycon.handhelds.aya_gen7 as aya_gen7
 import handycon.handhelds.ayn_gen1 as ayn_gen1
 import handycon.handhelds.gpd_gen1 as gpd_gen1
 import handycon.handhelds.gpd_gen2 as gpd_gen2
@@ -149,7 +150,7 @@ def id_system():
         "AIR 1S",
         ):
         handycon.system_type = "AYA_GEN7"
-        aya_gen6.init_handheld(handycon)
+        aya_gen7.init_handheld(handycon)
 
     ## Ayn Devices
     elif system_id in (

--- a/src/handycon/utilities.py
+++ b/src/handycon/utilities.py
@@ -144,6 +144,12 @@ def id_system():
         ):
         handycon.system_type = "AYA_GEN6"
         aya_gen6.init_handheld(handycon)
+    
+    elif system_id in (
+        "AIR 1S",
+        ):
+        handycon.system_type = "AYA_GEN7"
+        aya_gen6.init_handheld(handycon)
 
     ## Ayn Devices
     elif system_id in (


### PR DESCRIPTION
This pr adds initial support for ayaneo air 1s. The bottom right small button is a bit tricky to work with - the python code doesn't seem to capture the button-up event reliably. 