### PR TITLE
Added support for the Ayaneo Air 1S Ultra

### DIFF
--- a/src/handycon/utilities.py
+++ b/src/handycon/utilities.py
@@ -172,6 +172,7 @@ def id_system():
         "AYANEO 2S",
         "GEEK 1S",
         "AIR 1S",
+        "AIR 1S Limited",
     ):
         handycon.system_type = "AYA_GEN6"
         aya_gen6.init_handheld(handycon)


### PR DESCRIPTION
Tested on ChimeraOS 45, seems to work fine on the Steam UI.

It should behave exactly the same as the regular Air 1S, but for some reason Ayaneo gave it a different product name.